### PR TITLE
Update maven-gpg-plugin to version 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -355,7 +360,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Hi Michael !   When I run the current version of   https://github.com/shinesolutions/aem-password-reset    I was getting some maven warnings about the gpg plugin version ...  Something like this seems to help.
